### PR TITLE
refactor: use generic Page<T>() method and simplify config loading

### DIFF
--- a/PlaywrightReqnrollFramework/Config/TestSettings.cs
+++ b/PlaywrightReqnrollFramework/Config/TestSettings.cs
@@ -4,11 +4,29 @@ namespace PlaywrightReqnrollFramework.Config;
 
 public class TestSettings
 {
-    public float Timeout { get; set; } = 30f; // Default timeout in seconds
+    /// <summary>
+    /// Timeout in seconds for page operations (will be converted to milliseconds for Playwright)
+    /// </summary>
+    public float Timeout { get; set; } = 30f;
+    
+    /// <summary>
+    /// Run browser in headless mode (no UI)
+    /// </summary>
     public bool Headless { get; set; } = false;
-    public int SlowMo { get; set; } = 500; // Slow down operations by 500ms
-    public string BaseUrl { get; set; } = "https://www.saucedemo.com"; // Default base URL
+    
+    /// <summary>
+    /// Slow down operations by specified milliseconds (useful for debugging)
+    /// </summary>
+    public int SlowMo { get; set; } = 500;
+    
+    /// <summary>
+    /// Base URL for the application under test
+    /// </summary>
+    public string BaseUrl { get; set; } = "https://www.saucedemo.com";
 
+    /// <summary>
+    /// Browser type to use for testing
+    /// </summary>
     public BrowserTypeEnum BrowserType { get; set; }
 
     public enum BrowserTypeEnum

--- a/PlaywrightReqnrollFramework/Hook/Hooks.cs
+++ b/PlaywrightReqnrollFramework/Hook/Hooks.cs
@@ -23,22 +23,17 @@ public class Hooks(ScenarioContext scenarioContext)
     [BeforeScenario("@web")]
     public async Task IntializePlaywright()
     {
-        var settings = ConfigReader.LoadSettings();
-        TestSettings testSettings = new TestSettings
-        {
-            Headless = settings.Headless, // Set to true for headless mode
-            SlowMo = settings.SlowMo, // Slow down operations by ms
-            Timeout = settings.Timeout, // Slow down operations by ms
-            BaseUrl = settings.BaseUrl, // Set your base URL
-            BrowserType = settings.BrowserType // Choose your browser type
-        };
+        // Load settings directly from configuration
+        var testSettings = ConfigReader.LoadSettings();
+        
         _driver = new PlaywrightDriver(testSettings);
         var page = await _driver.InitializeAsync();
-        page.SetDefaultTimeout(testSettings.Timeout);
+        
+        // Set default timeout (convert seconds to milliseconds for Playwright)
+        page.SetDefaultTimeout(testSettings.Timeout * 1000);
+        
         _scenarioContext.Set(page, "currentPage");
         _scenarioContext.Set(testSettings, "testSettings");
-
-
     }
 
     [AfterScenario("@web")]

--- a/PlaywrightReqnrollFramework/Pages/BasePage.cs
+++ b/PlaywrightReqnrollFramework/Pages/BasePage.cs
@@ -1,7 +1,5 @@
 using System;
-using AventStack.ExtentReports.Model;
 using Microsoft.Playwright;
-using PlaywrightReqnrollFramework.Config;
 using Reqnroll;
 
 namespace PlaywrightReqnrollFramework.Pages;
@@ -9,9 +7,5 @@ namespace PlaywrightReqnrollFramework.Pages;
 public abstract class BasePage(ScenarioContext scenarioContext)
 {
     protected readonly IPage _page = scenarioContext.Get<IPage>("currentPage");
-
     protected readonly ScenarioContext _scenarioContext = scenarioContext;
-    protected readonly TestSettings _testSettings = scenarioContext.Get<TestSettings>("testSettings");
-
-   
 }

--- a/PlaywrightReqnrollFramework/StepDefinitions/BaseSteps.cs
+++ b/PlaywrightReqnrollFramework/StepDefinitions/BaseSteps.cs
@@ -13,12 +13,10 @@ public class BaseSteps
         Factory = new PageFactory(scenarioContext);
     }
 
-    protected InventoryPage InventoryPage => Factory.GetPage<InventoryPage>();
-    protected ProductPage ProductPage => Factory.GetPage<ProductPage>();
-    protected CheckoutPage CheckoutPage => Factory.GetPage<CheckoutPage>();
-    protected CheckoutOverviewPage CheckoutOverviewPage => Factory.GetPage<CheckoutOverviewPage>();
-    protected CheckoutCompletePage CheckoutCompletePage => Factory.GetPage<CheckoutCompletePage>();
-
-    protected LoginPage LoginPage => Factory.GetPage<LoginPage>();
-    
+    /// <summary>
+    /// Gets an instance of the specified page type from the PageFactory.
+    /// </summary>
+    /// <typeparam name="T">The type of page to retrieve, must inherit from BasePage</typeparam>
+    /// <returns>An instance of the requested page</returns>
+    protected T Page<T>() where T : BasePage => Factory.GetPage<T>();
 }

--- a/PlaywrightReqnrollFramework/StepDefinitions/InventoryStepDef.cs
+++ b/PlaywrightReqnrollFramework/StepDefinitions/InventoryStepDef.cs
@@ -19,8 +19,8 @@ public class InventoryStepDef(ScenarioContext scenarioContext) : BaseSteps(scena
 
         foreach (var item in items)
         {
-            await ProductPage.AddProductToCartAsync(item.ItemName);
-            var itemPrice = await ProductPage.GetProductPriceAsync(item.ItemName);
+            await Page<ProductPage>().AddProductToCartAsync(item.ItemName);
+            var itemPrice = await Page<ProductPage>().GetProductPriceAsync(item.ItemName);
             totalPrice += float.Parse(itemPrice);
 
         }
@@ -31,7 +31,7 @@ public class InventoryStepDef(ScenarioContext scenarioContext) : BaseSteps(scena
     [Then(@"I navigate to the cart")]
     public async Task ThenInavigatetothecartAsync()
     {
-       await ProductPage.NavigateToCartAsync();
+       await Page<ProductPage>().NavigateToCartAsync();
     }
 
 
@@ -42,9 +42,9 @@ public class InventoryStepDef(ScenarioContext scenarioContext) : BaseSteps(scena
 
         foreach (var item in items)
         {
-            bool isProductVisible = await InventoryPage.isProductInInventoryAsync(item.ItemName);
+            bool isProductVisible = await Page<InventoryPage>().isProductInInventoryAsync(item.ItemName);
             Assert.That(isProductVisible, Is.True, $"Product '{item.ItemName}' is not visible in the inventory.");
-            float productPrice = await InventoryPage.GetProductPriceAsync(item.ItemName);
+            float productPrice = await Page<InventoryPage>().GetProductPriceAsync(item.ItemName);
             Assert.That(productPrice, Is.EqualTo(item.ItemPrice), $"Product price for '{item.ItemName}' does not match. Expected: {item.ItemPrice}, Actual: {productPrice}");
         }
     }
@@ -53,14 +53,14 @@ public class InventoryStepDef(ScenarioContext scenarioContext) : BaseSteps(scena
     [Then(@"I clicked on the checkout button")]
     public async Task ThenIclickedonthecheckoutbuttonAsync()
     {
-        await InventoryPage.ClickCheckoutAsync();
+        await Page<InventoryPage>().ClickCheckoutAsync();
     }
 
 
     [Then(@"I should be redirected to the checkout page")]
     public async Task ThenIshouldberedirectedtothecheckoutpageAsync()
     {
-        bool isCheckedOutPage = await CheckoutPage.IsCheckoutTitleVisibleAsync();
+        bool isCheckedOutPage = await Page<CheckoutPage>().IsCheckoutTitleVisibleAsync();
         Assert.That(isCheckedOutPage, Is.True, "Checkout page is not loaded after clicking checkout button.");
     }
 
@@ -71,7 +71,7 @@ public class InventoryStepDef(ScenarioContext scenarioContext) : BaseSteps(scena
         //CrateInstance only fetch first row of the table
         //If you want to fetch all rows, use CreateSet<T>() method
         var details = table.CreateInstance<CheckoutDetails>();
-        CheckoutPage.FillCheckoutFormAsync(details.FirstName, details.LastName, details.PostalCode).GetAwaiter().GetResult();
+        Page<CheckoutPage>().FillCheckoutFormAsync(details.FirstName, details.LastName, details.PostalCode).GetAwaiter().GetResult();
 
     }
 
@@ -79,14 +79,14 @@ public class InventoryStepDef(ScenarioContext scenarioContext) : BaseSteps(scena
     [When(@"I click on the continue button")]
     public async Task WhenIclickonthecontinuebutton()
     {
-        await CheckoutPage.ClickContinueButtonAsync();
+        await Page<CheckoutPage>().ClickContinueButtonAsync();
     }
 
 
     [Then(@"I should be redirected to the overview page")]
     public async Task ThenIshouldberedirectedtotheoverviewpageAsync()
     {
-       await CheckoutOverviewPage.IsCheckoutOverviewTitleVisibleAsync();
+       await Page<CheckoutOverviewPage>().IsCheckoutOverviewTitleVisibleAsync();
     }
 
 
@@ -97,8 +97,8 @@ public class InventoryStepDef(ScenarioContext scenarioContext) : BaseSteps(scena
 
         foreach (var item in items)
         {
-            await CheckoutOverviewPage.IsProductInCheckoutOverviewAsync(item.ItemName);
-            float productPrice = await CheckoutOverviewPage.GetProductPriceAsync(item.ItemName);
+            await Page<CheckoutOverviewPage>().IsProductInCheckoutOverviewAsync(item.ItemName);
+            float productPrice = await Page<CheckoutOverviewPage>().GetProductPriceAsync(item.ItemName);
             Assert.That(productPrice, Is.EqualTo(item.ItemPrice), $"Product price for '{item.ItemName}' does not match. Expected: {item.ItemPrice}, Actual: {productPrice}");
         }
     }
@@ -108,7 +108,7 @@ public class InventoryStepDef(ScenarioContext scenarioContext) : BaseSteps(scena
     public async Task ThenTheItemtotalshouldbeAsync(float expectedItemTotal)
     {
 
-        float actualItemTotal = await CheckoutOverviewPage.GetItemTotalAsync();
+        float actualItemTotal = await Page<CheckoutOverviewPage>().GetItemTotalAsync();
         Assert.That(actualItemTotal, Is.EqualTo(expectedItemTotal), $"Expected Item Total: {expectedItemTotal}, Actual Item Total: {actualItemTotal}");
     }
 
@@ -116,14 +116,14 @@ public class InventoryStepDef(ScenarioContext scenarioContext) : BaseSteps(scena
     [Then(@"The Tax should be {float}")]
     public async Task ThenTheTaxshouldbeAsync(float expectedTax)
     {
-        float actualTax = await CheckoutOverviewPage.GetTaxAsync();
+        float actualTax = await Page<CheckoutOverviewPage>().GetTaxAsync();
         Assert.That(actualTax, Is.EqualTo(expectedTax), $"Expected Tax: {expectedTax}, Actual Tax: {actualTax}");
     }
 
     [Then(@"The Total should be {float}")]
     public async Task ThenTheTotalshouldbeAsync(float expectedGrandTotal)
     {
-        float actualTotal = await CheckoutOverviewPage.GetTotalAsync();
+        float actualTotal = await Page<CheckoutOverviewPage>().GetTotalAsync();
         Assert.That(actualTotal, Is.EqualTo(expectedGrandTotal), $"Expected Total: {expectedGrandTotal}, Actual Total: {actualTotal}");
     }
 
@@ -131,20 +131,20 @@ public class InventoryStepDef(ScenarioContext scenarioContext) : BaseSteps(scena
     [When(@"I click on the finish button")]
     public async Task WhenIclickonthefinishbuttonAsync()
     {
-       await CheckoutOverviewPage.ClickFinishButtonAsync();
+       await Page<CheckoutOverviewPage>().ClickFinishButtonAsync();
     }
 
     [Then(@"I should see the confirmation message ""(.*)""")]
     public async Task ThenIshouldseetheconfirmationmessageAsync(string args1)
     {
-        await CheckoutCompletePage.IsCheckoutCompleteMessageVisibleAsync();
+        await Page<CheckoutCompletePage>().IsCheckoutCompleteMessageVisibleAsync();
 
     }
 
     [When(@"I click on the back home button")]
     public async Task WhenIclickonthebackhomebuttonAsync()
     {
-        await CheckoutCompletePage.ClickBackHomeButtonAsync();
+        await Page<CheckoutCompletePage>().ClickBackHomeButtonAsync();
     }
 
 

--- a/PlaywrightReqnrollFramework/StepDefinitions/LoginStepDef.cs
+++ b/PlaywrightReqnrollFramework/StepDefinitions/LoginStepDef.cs
@@ -14,26 +14,26 @@ namespace PlaywrightReqnrollFramework.LoginStepDef
         [Given(@"I navigate to {string}")]
         public async Task GivenINavigateTo(string url)
         {
-             await LoginPage.NavigateToAsync(url);
+             await Page<LoginPage>().NavigateToAsync(url);
         }
 
         [When("I login with username {string} and password {string}")]
         public async Task WhenILoginWithUsernameAndPasswordAsync(string username, string password)
         {
-            await LoginPage.LoginAsync(username, password);
+            await Page<LoginPage>().LoginAsync(username, password);
         }
 
         [Then(@"I should be redirected to the inventory page")]
         public async Task ThenIshouldberedirectedtotheinventorypageAsync()
         {
-            bool isInventoryPageLoaded = await ProductPage.IsInventoryPageLoadedAsync();
+            bool isInventoryPageLoaded = await Page<ProductPage>().IsInventoryPageLoadedAsync();
             Assert.That(isInventoryPageLoaded, Is.True, "Inventory page is not loaded after login.");
         }
 
         [Then(@"I should see the products header")]
         public async Task ThenIshouldseetheproductsheaderAsync()
         {
-            bool isVisible = await ProductPage.IsInventoryPageLoadedAsync();
+            bool isVisible = await Page<ProductPage>().IsInventoryPageLoadedAsync();
             Assert.That(isVisible, Is.True, "The 'Products' header is not visible on the page.");
         }
 
@@ -41,9 +41,9 @@ namespace PlaywrightReqnrollFramework.LoginStepDef
         [Then(@"I should see the error message ""(.*)""")]
         public async Task ThenIshouldseetheerrormessageAsync(string errorMessage)
         {
-            bool isErrorMessageVisible = await LoginPage.IsErrorMessageVisibleAsync();
+            bool isErrorMessageVisible = await Page<LoginPage>().IsErrorMessageVisibleAsync();
             Assert.That(isErrorMessageVisible, Is.True, "Error message is not visible.");
-            string actualErrorMessage = await LoginPage.GetErrorMessageTextAsync();
+            string actualErrorMessage = await Page<LoginPage>().GetErrorMessageTextAsync();
             Assert.That(actualErrorMessage, Is.EqualTo(errorMessage), $"Expected error message '{errorMessage}' but got '{actualErrorMessage}'.");
         }
 

--- a/PlaywrightReqnrollFramework/appsettings.json
+++ b/PlaywrightReqnrollFramework/appsettings.json
@@ -5,6 +5,6 @@
   "BaseUrl" : "https://www.saucedemo.com",
   "Headless": false,
   "SlowMo": 500,
-  "Timeout": 20000,
+  "Timeout": 30,
   "BrowserType": "Firefox"  
 }

--- a/PlaywrightReqnrollFramework/ci.appsettings.json
+++ b/PlaywrightReqnrollFramework/ci.appsettings.json
@@ -5,6 +5,6 @@
   "BaseUrl" : "https://www.saucedemo.com",
   "Headless": true,
   "SlowMo": 0,
-  "Timeout": 20000,
+  "Timeout": 30,
   "BrowserType": "Firefox"  
 }

--- a/PlaywrightReqnrollFramework/dev.appsettings.json
+++ b/PlaywrightReqnrollFramework/dev.appsettings.json
@@ -5,6 +5,6 @@
   "BaseUrl" : "https://www.saucedemo.com",
   "Headless": false,
   "SlowMo": 500,
-  "Timeout": 20000,
+  "Timeout": 30,
   "BrowserType": "Firefox"  
 }


### PR DESCRIPTION
- Replace individual page properties with Page<T>() helper in BaseSteps
- Remove redundant TestSettings creation in Hooks, use ConfigReader directly
- Remove unused _testSettings from BasePage
- Fix timeout units: use seconds in config files (30s instead of 20000ms)