### PR TITLE
refactor: standardize Page Object Model with decimal types and proper async patterns

### DIFF
--- a/PlaywrightReqnrollFramework/Config/TestSettings.cs
+++ b/PlaywrightReqnrollFramework/Config/TestSettings.cs
@@ -19,10 +19,6 @@ public class TestSettings
     /// </summary>
     public int SlowMo { get; set; } = 500;
     
-    /// <summary>
-    /// Base URL for the application under test
-    /// </summary>
-    public string BaseUrl { get; set; } = "https://www.saucedemo.com";
 
     /// <summary>
     /// Browser type to use for testing

--- a/PlaywrightReqnrollFramework/Hook/Hooks.cs
+++ b/PlaywrightReqnrollFramework/Hook/Hooks.cs
@@ -1,46 +1,60 @@
 using System;
-using System.IO;
 using System.Threading.Tasks;
-using AventStack.ExtentReports;
-using AventStack.ExtentReports.Gherkin.Model;
-using AventStack.ExtentReports.Reporter;
 using PlaywrightReqnrollFramework.Config;
 using PlaywrightReqnrollFramework.Driver;
 using Reqnroll;
-using static PlaywrightReqnrollFramework.Config.TestSettings;
 
 namespace PlaywrightReqnrollFramework.Hook;
 
 [Binding]
 public class Hooks(ScenarioContext scenarioContext)
 {
-    private static PlaywrightDriver _driver;
-
+    private PlaywrightDriver _driver;
     private readonly ScenarioContext _scenarioContext = scenarioContext;
-    
 
-    //This method is executed before each scenario tagged with @web
+    /// <summary>
+    /// Initialize Playwright browser before each scenario tagged with @web
+    /// </summary>
     [BeforeScenario("@web")]
-    public async Task IntializePlaywright()
+    public async Task InitializePlaywright()
     {
-        // Load settings directly from configuration
-        var testSettings = ConfigReader.LoadSettings();
-        
-        _driver = new PlaywrightDriver(testSettings);
-        var page = await _driver.InitializeAsync();
-        
-        // Set default timeout (convert seconds to milliseconds for Playwright)
-        page.SetDefaultTimeout(testSettings.Timeout * 1000);
-        
-        _scenarioContext.Set(page, "currentPage");
-        _scenarioContext.Set(testSettings, "testSettings");
+        try
+        {
+            // Load settings directly from configuration
+            var testSettings = ConfigReader.LoadSettings();
+
+            _driver = new PlaywrightDriver(testSettings);
+            var page = await _driver.InitializeAsync();
+
+            // Set default timeout (convert seconds to milliseconds for Playwright)
+            page.SetDefaultTimeout(testSettings.Timeout * 1000);
+
+            _scenarioContext.Set(page, "currentPage");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Failed to initialize Playwright: {ex.Message}");
+            throw;
+        }
     }
 
+    /// <summary>
+    /// Cleanup browser resources after each scenario tagged with @web
+    /// </summary>
     [AfterScenario("@web")]
-    public static async Task AfterScenario()
+    public async Task CleanupPlaywright()
     {
-        await _driver.DisposeAsync();
+        try
+        {
+            if (_driver != null)
+            {
+                await _driver.DisposeAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error during cleanup: {ex.Message}");
+            // Don't rethrow - cleanup errors shouldn't fail the test
+        }
     }
-
-   
 }

--- a/PlaywrightReqnrollFramework/Pages/BasePage.cs
+++ b/PlaywrightReqnrollFramework/Pages/BasePage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Microsoft.Playwright;
 using Reqnroll;
 
@@ -8,4 +9,24 @@ public abstract class BasePage(ScenarioContext scenarioContext)
 {
     protected readonly IPage _page = scenarioContext.Get<IPage>("currentPage");
     protected readonly ScenarioContext _scenarioContext = scenarioContext;
+
+    /// <summary>
+    /// Parses a price string (e.g., "$12.99") to a decimal value
+    /// </summary>
+    /// <param name="priceText">Price text with or without currency symbol</param>
+    /// <returns>Decimal value of the price</returns>
+    protected decimal ParsePrice(string priceText)
+    {
+        if (string.IsNullOrWhiteSpace(priceText))
+            throw new ArgumentException("Price text cannot be null or empty", nameof(priceText));
+
+        var cleanedPrice = priceText.Replace("$", "").Replace("Item total:", "").Replace("Tax:", "").Replace("Total:", "").Trim();
+        
+        if (decimal.TryParse(cleanedPrice, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var price))
+        {
+            return price;
+        }
+        
+        throw new FormatException($"Unable to parse price from text: '{priceText}'");
+    }
 }

--- a/PlaywrightReqnrollFramework/Pages/CheckoutCompletePage.cs
+++ b/PlaywrightReqnrollFramework/Pages/CheckoutCompletePage.cs
@@ -23,13 +23,6 @@ public class CheckoutCompletePage(ScenarioContext scenarioContext) : BasePage(sc
     }
     public async Task ClickBackHomeButtonAsync()
     {
-        if (await BackHomeButton.IsVisibleAsync())
-        {
-            await BackHomeButton.ClickAsync();
-        }
-        else
-        {
-            throw new Exception("Back Home button is not visible.");
-        }
+        await BackHomeButton.ClickAsync();
     }
 }

--- a/PlaywrightReqnrollFramework/Pages/CheckoutOverviewPage.cs
+++ b/PlaywrightReqnrollFramework/Pages/CheckoutOverviewPage.cs
@@ -40,81 +40,54 @@ public class CheckoutOverviewPage(ScenarioContext scenarioContext) : BasePage(sc
         return await title.IsVisibleAsync() && (await title.InnerTextAsync()) == "Checkout: Overview";
     }
 
-    public async Task IsProductInCheckoutOverviewAsync(string productName)
+    public async Task<bool> IsProductInCheckoutOverviewAsync(string productName)
     {
         var productLocator = GetProductName(productName);
-        if (!await productLocator.IsVisibleAsync())
-        {
-            throw new Exception($"Product '{productName}' is not present in the checkout overview.");
-        }
+        return await productLocator.IsVisibleAsync();
     }
-    public async Task<float> GetProductPriceAsync(string productName)
+
+    public async Task<decimal> GetProductPriceAsync(string productName)
     {
         var priceLocator = GetProductPrice(productName);
-        if (!await priceLocator.IsVisibleAsync())
-        {
-            throw new Exception($"Product '{productName}' is not present in the checkout overview.");
-        }
         var priceText = await priceLocator.InnerTextAsync();
-        return float.Parse(priceText.Replace("$", ""));
+        return ParsePrice(priceText);
     }
-    public async Task<float> GetItemTotalAsync()
+
+    public async Task<decimal> GetItemTotalAsync()
     {
         var itemTotalText = await ItemTotal.InnerTextAsync();
-        return float.Parse(itemTotalText.Replace("Item total: $", ""));
+        return ParsePrice(itemTotalText);
     }
-    public async Task<float> GetTaxAsync()
+
+    public async Task<decimal> GetTaxAsync()
     {
         var taxText = await Tax.InnerTextAsync();
-        return float.Parse(taxText.Replace("Tax: $", ""));
+        return ParsePrice(taxText);
     }
-    public async Task<float> GetTotalAsync()
+
+    public async Task<decimal> GetTotalAsync()
     {
         var totalText = await Total.InnerTextAsync();
-        return float.Parse(totalText.Replace("Total: $", ""));
+        return ParsePrice(totalText);
     }
+
     public async Task ClickFinishButtonAsync()
     {
-        if (await FinishButton.IsVisibleAsync())
-        {
-            await FinishButton.ClickAsync();
-        }
-        else
-        {
-            throw new Exception("Finish button is not visible.");
-        }
+        await FinishButton.ClickAsync();
     }
+
     public async Task ClickCancelButtonAsync()
     {
-        if (await CancelButton.IsVisibleAsync())
-        {
-            await CancelButton.ClickAsync();
-        }
-        else
-        {
-            throw new Exception("Cancel button is not visible.");
-        }
+        await CancelButton.ClickAsync();
     }
+
     public async Task<string> GetPaymentInfoAsync()
     {
-        if (await PaymentInfo.IsVisibleAsync())
-        {
-            return await PaymentInfo.InnerTextAsync();
-        }
-        else
-        {
-            throw new Exception("Payment information is not visible.");
-        }
+        return await PaymentInfo.InnerTextAsync();
     }
+
     public async Task<string> GetShippingInfoAsync()
     {
-        if (await ShippingInfo.IsVisibleAsync())
-        {
-            return await ShippingInfo.InnerTextAsync();
-        }
-        else
-        {
-            throw new Exception("Shipping information is not visible.");
-        }
+        return await ShippingInfo.InnerTextAsync();
     }
 }

--- a/PlaywrightReqnrollFramework/Pages/InventoryPage.cs
+++ b/PlaywrightReqnrollFramework/Pages/InventoryPage.cs
@@ -46,22 +46,12 @@ public class InventoryPage(ScenarioContext scenarioContext) : BasePage(scenarioC
     public async Task RemoveProductFromCartAsync(string productName)
     {
         var removeButton = GetInventoryRemoveBtn(productName);
-        if (await removeButton.IsVisibleAsync())
-        {
-            await removeButton.ClickAsync();
-        }
+        await removeButton.ClickAsync();
     }
-    public async Task<float> GetProductPriceAsync(string productName)
+    public async Task<decimal> GetProductPriceAsync(string productName)
     {
         var priceLocator = GetInventoryItemPrice(productName);
-        if (await priceLocator.IsVisibleAsync())
-        {
-            var priceText = await priceLocator.InnerTextAsync();
-            return float.Parse(priceText.Replace("$", "").Trim());
-        }
-        else
-        {
-            throw new Exception($"Price for '{productName}' is not visible.");
-        }
+        var priceText = await priceLocator.InnerTextAsync();
+        return ParsePrice(priceText);
     }
 }

--- a/PlaywrightReqnrollFramework/Pages/ProductPage.cs
+++ b/PlaywrightReqnrollFramework/Pages/ProductPage.cs
@@ -55,26 +55,14 @@ public class ProductPage(ScenarioContext scenarioContext) : BasePage(scenarioCon
     public async Task AddProductToCartAsync(string productName)
     {
         var addToCartButton = GetAddToCartButton(productName);
-        if (await addToCartButton.IsVisibleAsync())
-        {
-            await addToCartButton.ClickAsync();
-        }
-        else
-        {
-            throw new Exception($"Add to cart button for '{productName}' is not visible.");
-        }
+        await addToCartButton.ClickAsync();
     }
-    public async Task<string> GetProductPriceAsync(string productName)
+
+    public async Task<decimal> GetProductPriceAsync(string productName)
     {
         var priceLocator = GetProductPrice(productName);
-        if (await priceLocator.IsVisibleAsync())
-        {
-            return priceLocator.InnerTextAsync().Result.Replace("$", "").Trim();
-        }
-        else
-        {
-            throw new Exception($"Price for '{productName}' is not visible.");
-        }
+        var priceText = await priceLocator.InnerTextAsync();
+        return ParsePrice(priceText);
     }
     public async Task<bool> IsProductInCartAsync(string productName)
     {

--- a/PlaywrightReqnrollFramework/StepDefinitions/InventoryStepDef.cs
+++ b/PlaywrightReqnrollFramework/StepDefinitions/InventoryStepDef.cs
@@ -10,7 +10,7 @@ namespace PlaywrightReqnrollFramework.StepDefinitions;
 [Binding]
 public class InventoryStepDef(ScenarioContext scenarioContext) : BaseSteps(scenarioContext)
 {
-    private float totalPrice = 0.0f;
+    private decimal totalPrice = 0.0m;
 
     [When(@"I add following item to the cart")]
     public async Task WhenIaddfollowingitemtothecart(DataTable table)
@@ -21,7 +21,7 @@ public class InventoryStepDef(ScenarioContext scenarioContext) : BaseSteps(scena
         {
             await Page<ProductPage>().AddProductToCartAsync(item.ItemName);
             var itemPrice = await Page<ProductPage>().GetProductPriceAsync(item.ItemName);
-            totalPrice += float.Parse(itemPrice);
+            totalPrice += itemPrice;
 
         }
         Console.WriteLine($"Total Price of items in cart: {totalPrice}");
@@ -44,7 +44,7 @@ public class InventoryStepDef(ScenarioContext scenarioContext) : BaseSteps(scena
         {
             bool isProductVisible = await Page<InventoryPage>().isProductInInventoryAsync(item.ItemName);
             Assert.That(isProductVisible, Is.True, $"Product '{item.ItemName}' is not visible in the inventory.");
-            float productPrice = await Page<InventoryPage>().GetProductPriceAsync(item.ItemName);
+            decimal productPrice = await Page<InventoryPage>().GetProductPriceAsync(item.ItemName);
             Assert.That(productPrice, Is.EqualTo(item.ItemPrice), $"Product price for '{item.ItemName}' does not match. Expected: {item.ItemPrice}, Actual: {productPrice}");
         }
     }
@@ -97,33 +97,33 @@ public class InventoryStepDef(ScenarioContext scenarioContext) : BaseSteps(scena
 
         foreach (var item in items)
         {
-            await Page<CheckoutOverviewPage>().IsProductInCheckoutOverviewAsync(item.ItemName);
-            float productPrice = await Page<CheckoutOverviewPage>().GetProductPriceAsync(item.ItemName);
+            bool isProductVisible = await Page<CheckoutOverviewPage>().IsProductInCheckoutOverviewAsync(item.ItemName);
+            Assert.That(isProductVisible, Is.True, $"Product '{item.ItemName}' is not visible in the checkout overview.");
+            decimal productPrice = await Page<CheckoutOverviewPage>().GetProductPriceAsync(item.ItemName);
             Assert.That(productPrice, Is.EqualTo(item.ItemPrice), $"Product price for '{item.ItemName}' does not match. Expected: {item.ItemPrice}, Actual: {productPrice}");
         }
     }
 
 
-    [Then(@"The Item total should be {float}")]
-    public async Task ThenTheItemtotalshouldbeAsync(float expectedItemTotal)
+    [Then(@"The Item total should be {decimal}")]
+    public async Task ThenTheItemtotalshouldbeAsync(decimal expectedItemTotal)
     {
-
-        float actualItemTotal = await Page<CheckoutOverviewPage>().GetItemTotalAsync();
+        decimal actualItemTotal = await Page<CheckoutOverviewPage>().GetItemTotalAsync();
         Assert.That(actualItemTotal, Is.EqualTo(expectedItemTotal), $"Expected Item Total: {expectedItemTotal}, Actual Item Total: {actualItemTotal}");
     }
 
 
-    [Then(@"The Tax should be {float}")]
-    public async Task ThenTheTaxshouldbeAsync(float expectedTax)
+    [Then(@"The Tax should be {decimal}")]
+    public async Task ThenTheTaxshouldbeAsync(decimal expectedTax)
     {
-        float actualTax = await Page<CheckoutOverviewPage>().GetTaxAsync();
+        decimal actualTax = await Page<CheckoutOverviewPage>().GetTaxAsync();
         Assert.That(actualTax, Is.EqualTo(expectedTax), $"Expected Tax: {expectedTax}, Actual Tax: {actualTax}");
     }
 
-    [Then(@"The Total should be {float}")]
-    public async Task ThenTheTotalshouldbeAsync(float expectedGrandTotal)
+    [Then(@"The Total should be {decimal}")]
+    public async Task ThenTheTotalshouldbeAsync(decimal expectedGrandTotal)
     {
-        float actualTotal = await Page<CheckoutOverviewPage>().GetTotalAsync();
+        decimal actualTotal = await Page<CheckoutOverviewPage>().GetTotalAsync();
         Assert.That(actualTotal, Is.EqualTo(expectedGrandTotal), $"Expected Total: {expectedGrandTotal}, Actual Total: {actualTotal}");
     }
 

--- a/PlaywrightReqnrollFramework/StepDefinitions/InventoryStepDef.cs
+++ b/PlaywrightReqnrollFramework/StepDefinitions/InventoryStepDef.cs
@@ -66,13 +66,12 @@ public class InventoryStepDef(ScenarioContext scenarioContext) : BaseSteps(scena
 
 
     [When(@"I fill the checkout form with following details")]
-    public void WhenIfillthecheckoutformwithfollowingdetails(DataTable table)
+    public async Task WhenIfillthecheckoutformwithfollowingdetails(DataTable table)
     {
-        //CrateInstance only fetch first row of the table
+        //CreateInstance only fetch first row of the table
         //If you want to fetch all rows, use CreateSet<T>() method
         var details = table.CreateInstance<CheckoutDetails>();
-        Page<CheckoutPage>().FillCheckoutFormAsync(details.FirstName, details.LastName, details.PostalCode).GetAwaiter().GetResult();
-
+        await Page<CheckoutPage>().FillCheckoutFormAsync(details.FirstName, details.LastName, details.PostalCode);
     }
 
 

--- a/PlaywrightReqnrollFramework/StepDefinitions/LoginStepDef.cs
+++ b/PlaywrightReqnrollFramework/StepDefinitions/LoginStepDef.cs
@@ -1,4 +1,3 @@
-using System.Data;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using PlaywrightReqnrollFramework.Pages;


### PR DESCRIPTION
- Fix .Result blocking call in ProductPage
- Standardize all price methods to return decimal instead of float/string
- Add centralized ParsePrice() helper in BasePage
- Remove redundant visibility checks (trust Playwright's auto-wait)
- Update step definitions to use decimal type